### PR TITLE
refactor: reduce frontend state management complexity by single stream adoption

### DIFF
--- a/backend/packages/tanstack-pydantic-ai/README.md
+++ b/backend/packages/tanstack-pydantic-ai/README.md
@@ -33,7 +33,7 @@ from pydantic_ai import Agent
 from tanstack_pydantic_ai import TanStackAIAdapter, InMemoryRunStore
 
 agent = Agent("openai:gpt-5-mini")
-store = InMemoryRunStore()  # For stateful continuation (any RunStorePort works)
+run_store = InMemoryRunStore()  # For stateful continuation (any RunStorePort works)
 
 app = FastAPI()
 
@@ -42,7 +42,7 @@ async def chat(request: Request):
     adapter = TanStackAIAdapter.from_request(
         agent=agent,
         body=await request.body(),
-        store=store,
+        run_store=run_store,
     )
     return StreamingResponse(
         adapter.streaming_response(),
@@ -65,13 +65,13 @@ adapter = TanStackAIAdapter.from_request(
     body=request_body,
     accept=None,           # Optional Accept header
     deps=None,             # Optional agent dependencies
-    store=None,            # Optional store for stateful continuation
+    run_store=run_store,   # RunStore for stateful continuation (required)
 )
 
 # Properties
 adapter.run_id              # Unique run ID for continuation
 adapter.is_continuation     # True if this is a continuation request
-adapter.message_history     # Loaded from store or request
+adapter.message_history     # Loaded from run_store or request (new runs)
 adapter.user_prompt         # Extracted user prompt
 
 # Streaming

--- a/backend/packages/tanstack-pydantic-ai/src/tanstack_pydantic_ai/adapter/__init__.py
+++ b/backend/packages/tanstack-pydantic-ai/src/tanstack_pydantic_ai/adapter/__init__.py
@@ -8,7 +8,7 @@ Usage:
     from tanstack_pydantic_ai.adapter import TanStackAIAdapter, TanStackEventStream
 
     # In FastAPI endpoint
-    adapter = TanStackAIAdapter.from_request(agent, body, store=store)
+    adapter = TanStackAIAdapter.from_request(agent, body, run_store=run_store)
     return StreamingResponse(
         adapter.streaming_response(),
         headers=dict(adapter.response_headers),

--- a/backend/src/backend/continuations.py
+++ b/backend/src/backend/continuations.py
@@ -1,0 +1,54 @@
+"""
+In-memory continuation hub for pattern A (single-stream HITL).
+
+Keeps a per-run queue of approvals/tool results so the streaming
+request can await human input and resume in the same SSE connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ContinuationPayload:
+    approvals: dict[str, bool | dict[str, Any]] = field(default_factory=dict)
+    tool_results: dict[str, Any] = field(default_factory=dict)
+
+
+class ContinuationHub:
+    def __init__(self) -> None:
+        self._queues: dict[str, asyncio.Queue[ContinuationPayload]] = {}
+        self._lock = asyncio.Lock()
+
+    async def _get_queue(self, run_id: str) -> asyncio.Queue[ContinuationPayload]:
+        async with self._lock:
+            return self._queues.setdefault(run_id, asyncio.Queue())
+
+    async def wait(
+        self, run_id: str, *, timeout: float | None = None
+    ) -> ContinuationPayload | None:
+        queue = await self._get_queue(run_id)
+        try:
+            if timeout is None:
+                return await queue.get()
+            return await asyncio.wait_for(queue.get(), timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def push(self, run_id: str, payload: ContinuationPayload) -> None:
+        queue = await self._get_queue(run_id)
+        queue.put_nowait(payload)
+
+    async def clear(self, run_id: str) -> None:
+        async with self._lock:
+            self._queues.pop(run_id, None)
+
+
+_continuation_hub = ContinuationHub()
+
+
+def get_continuation_hub() -> ContinuationHub:
+    return _continuation_hub

--- a/backend/src/backend/continuations.py
+++ b/backend/src/backend/continuations.py
@@ -1,5 +1,5 @@
 """
-In-memory continuation hub for pattern A (single-stream HITL).
+In-memory continuation hub for single-stream HITL pattern.
 
 Keeps a per-run queue of approvals/tool results so the streaming
 request can await human input and resume in the same SSE connection.

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -8,16 +8,22 @@ This module provides:
 
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import AsyncIterator
+from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from pydantic_ai import AgentRunResultEvent, DeferredToolRequests
 from structlog.contextvars import bound_contextvars
 from tanstack_pydantic_ai import TanStackAIAdapter
+from tanstack_pydantic_ai.shared.sse import encode_done
 
 from .agent import get_agent
+from .continuations import ContinuationPayload, get_continuation_hub
 from .db import get_db_connection
 from .deps import Deps
 from .logging import configure_logging, get_logger
@@ -47,6 +53,15 @@ app.add_middleware(
 
 # Run store for HITL continuation (swap via settings)
 store = get_run_store()
+continuation_hub = get_continuation_hub()
+
+KEEPALIVE_INTERVAL_SECONDS = 15.0
+
+
+class ContinuationRequest(BaseModel):
+    run_id: str
+    approvals: dict[str, bool | dict[str, Any]] = Field(default_factory=dict)
+    tool_results: dict[str, Any] = Field(default_factory=dict)
 
 
 def _sse_headers() -> dict[str, str]:
@@ -71,8 +86,6 @@ async def chat(request: Request) -> StreamingResponse:
 
     Returns SSE stream with TanStack AI compatible chunks.
     """
-    import json
-
     body = await request.body()
     accept = request.headers.get("accept")
 
@@ -115,8 +128,106 @@ async def chat(request: Request) -> StreamingResponse:
                     deps=deps,
                     store=store,
                 )
-                async for chunk in adapter.streaming_response():
-                    yield chunk
+                event_stream = adapter.build_event_stream()
+                model_name = adapter.run_input.model or settings.llm_model or "unknown"
+
+                def _usage_from_result(result: Any) -> dict[str, int] | None:
+                    if result is None:
+                        return None
+                    try:
+                        usage_data = result.usage()
+                    except Exception:
+                        return None
+                    if not usage_data:
+                        return None
+
+                    def _get_usage_value(*names: str) -> int | None:
+                        for name in names:
+                            if isinstance(usage_data, dict) and name in usage_data:
+                                return int(usage_data[name])
+                            if hasattr(usage_data, name):
+                                return int(getattr(usage_data, name))
+                        return None
+
+                    prompt_tokens = _get_usage_value(
+                        "prompt_tokens", "promptTokens", "input_tokens", "inputTokens"
+                    )
+                    completion_tokens = _get_usage_value(
+                        "completion_tokens",
+                        "completionTokens",
+                        "output_tokens",
+                        "outputTokens",
+                    )
+                    total_tokens = _get_usage_value("total_tokens", "totalTokens")
+
+                    if prompt_tokens is None or completion_tokens is None:
+                        return None
+                    if total_tokens is None:
+                        total_tokens = prompt_tokens + completion_tokens
+
+                    return {
+                        "promptTokens": prompt_tokens,
+                        "completionTokens": completion_tokens,
+                        "totalTokens": total_tokens,
+                    }
+
+                try:
+                    current_adapter = adapter
+                    while True:
+                        captured_result = None
+                        is_deferred = False
+
+                        async def capturing_native_events() -> AsyncIterator[Any]:
+                            nonlocal captured_result, is_deferred
+                            async for event in current_adapter.run_stream_native():
+                                if isinstance(event, AgentRunResultEvent):
+                                    captured_result = event.result
+                                    output = getattr(event.result, "output", None)
+                                    is_deferred = isinstance(
+                                        output, DeferredToolRequests
+                                    )
+                                yield event
+
+                        async for chunk in event_stream.transform_stream(
+                            capturing_native_events(),
+                            model_name=model_name,
+                            usage_provider=lambda: _usage_from_result(captured_result),
+                        ):
+                            if chunk.type == "done" and is_deferred:
+                                continue
+                            yield event_stream.encode_event(chunk).encode("utf-8")
+
+                        if not is_deferred:
+                            break
+
+                        while True:
+                            payload = await continuation_hub.wait(
+                                run_id, timeout=KEEPALIVE_INTERVAL_SECONDS
+                            )
+                            if payload is None:
+                                yield b": keep-alive\n\n"
+                                continue
+                            if not payload.approvals and not payload.tool_results:
+                                continue
+                            break
+
+                        continuation_body = json.dumps(
+                            {
+                                "run_id": run_id,
+                                "approvals": payload.approvals,
+                                "tool_results": payload.tool_results,
+                            }
+                        ).encode("utf-8")
+                        current_adapter = TanStackAIAdapter.from_request(
+                            agent=agent,
+                            body=continuation_body,
+                            accept=accept,
+                            deps=deps,
+                            store=store,
+                        )
+                finally:
+                    await continuation_hub.clear(run_id)
+                yield encode_done().encode("utf-8")
 
     return StreamingResponse(
         TanStackAIAdapter.stream_with_error_handling(
@@ -171,6 +282,27 @@ async def get_csv_data(
         "original_row_count": preview.original_row_count,
         "exported_row_count": preview.exported_row_count,
     }
+
+
+@app.post("/api/continuation")
+async def post_continuation(payload: ContinuationRequest) -> dict:
+    """
+    Accept approval/tool results and resume the open SSE stream (Pattern A).
+    """
+    if not payload.run_id:
+        raise HTTPException(status_code=400, detail="run_id is required")
+    if not payload.approvals and not payload.tool_results:
+        raise HTTPException(
+            status_code=400, detail="approvals or tool_results must be provided"
+        )
+
+    await continuation_hub.push(
+        payload.run_id,
+        ContinuationPayload(
+            approvals=payload.approvals, tool_results=payload.tool_results
+        ),
+    )
+    return {"status": "ok"}
 
 
 @app.get("/health")

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -52,7 +52,7 @@ app.add_middleware(
 )
 
 # Run store for HITL continuation (swap via settings)
-store = get_run_store()
+run_store = get_run_store()
 continuation_hub = get_continuation_hub()
 
 KEEPALIVE_INTERVAL_SECONDS = 15.0
@@ -126,7 +126,7 @@ async def chat(request: Request) -> StreamingResponse:
                     body=body,
                     accept=accept,
                     deps=deps,
-                    store=store,
+                    run_store=run_store,
                 )
                 event_stream = adapter.build_event_stream()
                 model_name = adapter.run_input.model or settings.llm_model or "unknown"
@@ -261,7 +261,7 @@ async def chat(request: Request) -> StreamingResponse:
                             body=continuation_body,
                             accept=accept,
                             deps=deps,
-                            store=store,
+                            run_store=run_store,
                         )
                 finally:
                     await continuation_hub.clear(run_id)

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -25,6 +25,7 @@ export function ChatPage() {
     approve,
     deny,
     resolveClientTool,
+    isContinuing,
     getRunIdForMessage,
   } = useChatSession();
 
@@ -38,11 +39,11 @@ export function ChatPage() {
   );
   const approvalsForPanel = useMemo(() => {
     if (hasPendingApprovals) return pendingApprovals;
-    if (isLoading && lastApproval) return [lastApproval];
+    if (isContinuing && lastApproval) return [lastApproval];
     return [];
-  }, [hasPendingApprovals, pendingApprovals, isLoading, lastApproval]);
+  }, [hasPendingApprovals, pendingApprovals, isContinuing, lastApproval]);
   const isProcessingApproval =
-    !hasPendingApprovals && !!lastApproval && isLoading;
+    !hasPendingApprovals && !!lastApproval && isContinuing;
 
   useEffect(() => {
     setVisibleError(error ?? null);
@@ -57,10 +58,10 @@ export function ChatPage() {
       setLastApproval(pendingApprovals[0] ?? null);
       return;
     }
-    if (!isLoading) {
+    if (!isContinuing) {
       setLastApproval(null);
     }
-  }, [hasPendingApprovals, pendingApprovals, isLoading]);
+  }, [hasPendingApprovals, pendingApprovals, isContinuing]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -129,7 +130,7 @@ export function ChatPage() {
                 pendingApprovalByToolCallId={pendingApprovalByToolCallId}
                 onApprove={approve}
                 onDeny={deny}
-                isLoading={isLoading}
+                isLoading={isContinuing}
                 showInlineApprovalActions={!hasPendingApprovals}
               />
             ))
@@ -139,7 +140,7 @@ export function ChatPage() {
           <ToolInputPanel
             clientTool={pendingClientTool}
             onComplete={resolveClientTool}
-            isLoading={isLoading}
+            isLoading={isContinuing}
           />
 
           {/* Scroll anchor */}
@@ -152,7 +153,7 @@ export function ChatPage() {
           approvals={approvalsForPanel}
           onApprove={approve}
           onDeny={deny}
-          isLoading={isLoading}
+          isLoading={isContinuing}
           isProcessing={isProcessingApproval}
         />
         {/* Input form */}

--- a/frontend/src/features/chat/chatConnection.ts
+++ b/frontend/src/features/chat/chatConnection.ts
@@ -1,27 +1,11 @@
 import { fetchServerSentEvents, type ConnectionAdapter } from "@tanstack/ai-react";
-import type { ContinuationState } from "./types";
 
 export function createChatConnection(
-  getContinuationState: () => ContinuationState,
+  getRunId: () => string | null,
   apiBase = ""
 ): ConnectionAdapter {
   return fetchServerSentEvents(`${apiBase}/api/chat`, async () => {
-    const { pending, runId, approvals, toolResults } = getContinuationState();
-    const hasApprovals = Object.keys(approvals).length > 0;
-    const hasToolResults = Object.keys(toolResults).length > 0;
-    const isContinuation = pending && !!runId && (hasApprovals || hasToolResults);
-
-    if (isContinuation) {
-      return {
-        headers: { Accept: "text/event-stream" },
-        body: {
-          run_id: runId,
-          approvals,
-          tool_results: toolResults,
-        },
-      };
-    }
-
+    const runId = getRunId();
     return {
       headers: { Accept: "text/event-stream" },
       body: runId ? { run_id: runId } : undefined,

--- a/frontend/src/features/chat/services/dataService.ts
+++ b/frontend/src/features/chat/services/dataService.ts
@@ -14,3 +14,25 @@ export async function fetchArtifactData(
   }
   return (await response.json()) as ArtifactData;
 }
+
+export async function postContinuation(
+  runId: string,
+  payload: {
+    approvals?: Record<string, boolean | Record<string, unknown>>;
+    toolResults?: Record<string, unknown>;
+  }
+): Promise<void> {
+  const response = await fetch("/api/continuation", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      run_id: runId,
+      approvals: payload.approvals ?? {},
+      tool_results: payload.toolResults ?? {},
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to continue run: ${response.statusText}`);
+  }
+}

--- a/frontend/src/features/chat/types/index.ts
+++ b/frontend/src/features/chat/types/index.ts
@@ -1,10 +1,3 @@
-export type ContinuationState = {
-  pending: boolean;
-  runId: string | null;
-  approvals: Record<string, boolean>;
-  toolResults: Record<string, unknown>;
-};
-
 export type ArtifactDataInline = {
   mode?: "inline";
   rows: Record<string, unknown>[];


### PR DESCRIPTION
added to backend
- `/api/continuation`
- ContinuationHub

removed from frontend
- `normalizeToolCallParts` and related message patching (`setMessages`)
- `continuationRef` (`ContinuationState`) and client-side auto-continue payload building
- Dependence on `addToolApprovalResponse` / `addToolResult` to trigger a new stream

---

fixed and removed from backend (stateful pattern)
- `run_store: RunStorePort` as required
- message_history:
   - stateless branching
   - pending injection
   - _find_unprocessed_tool_calls
